### PR TITLE
Improve.source.doctrine.qb

### DIFF
--- a/src/ZfTable/Source/DoctrineQueryBuilder.php
+++ b/src/ZfTable/Source/DoctrineQueryBuilder.php
@@ -63,12 +63,11 @@ class DoctrineQueryBuilder extends AbstractSource
         $header = $this->getTable()->getHeader($column);
         $tableAlias = ($header) ? $header->getTableAlias() : 'q';
 
-        if ($column) {
-            if (false === strpos($tableAlias, '.')) {
-                $tableAlias = $tableAlias.'.'.$column;
-            }
-            $this->query->orderBy($tableAlias, $order);
+        if (false === strpos($tableAlias, '.')) {
+            $tableAlias = $tableAlias.'.'.$column;
         }
+
+        $this->query->orderBy($tableAlias, $order);
     }
 
 


### PR DESCRIPTION
As an idea for simply field aliasing for doctrine query builder:

at configure grid $headers it's not possible to set column names from JOINED tables because this one could have same names as in root table.  

user
   :name

country
   :name

``` php

'name' => [
    'tableAlias' => 'c',
    'title' => $translator->translate('Company'),
    'filters' => 'text',
],
'postCode' => [
    'tableAlias' => 'a',
    'title' => $translator->translate('Post code'),
    'filters' => 'text',
    'width' => 100
],
'city' => [
    'tableAlias' => 'a',
    'title' => $translator->translate('City'),
    'filters' => 'text',
],
'country' => [ // here is a problem we need a name of company and can not
    'tableAlias' => 'l.name', // this is new in Doctrine QB at order() used as is no needed concatenate country string from header name
    'title' => $translator->translate('Country'),
    'filters' => 'text',
],

```

specially for ordering, filters used only if any exists in user land code. 
