### PR TITLE
Correct namespace

### DIFF
--- a/src/ZfTable/Decorator/Header/ClassDecorator.php
+++ b/src/ZfTable/Decorator/Header/ClassDecorator.php
@@ -6,7 +6,7 @@
  * @license   MIT License
  */
 
-namespace ZfTable\Decorator\Cell;
+namespace ZfTable\Decorator\Header;
 
 class ClassDecorator extends AbstractCellDecorator
 {


### PR DESCRIPTION
namespace ZfTable\Decorator\Cell -> namespace ZfTable\Decorator\Header

Lead to warning after composer update